### PR TITLE
remove: implicit secret configuration from temporary gh action token

### DIFF
--- a/.github/workflows/docker-production.yml
+++ b/.github/workflows/docker-production.yml
@@ -29,15 +29,6 @@ jobs:
           kubeconfig: ${{ secrets.KUBE_CONFIG }}
           context: ""
 
-      - name: Create image pull secret
-        run: |
-          kubectl create secret docker-registry ghcr-cred \
-            --docker-server=ghcr.io \
-            --docker-username=${{ github.actor }} \
-            --docker-password=${{ secrets.GITHUB_TOKEN }} \
-            --docker-email=ci@github.com \
-            --dry-run=client -o yaml | kubectl apply -f -
-
       - name: Update Kubernetes Deployment
         run: |
           echo "Updating Kubernetes Deployment with image: ghcr.io/fwu-de/telli-api:${{ env.COMMIT_HASH }}"

--- a/.github/workflows/docker-staging.yml
+++ b/.github/workflows/docker-staging.yml
@@ -67,15 +67,6 @@ jobs:
           kubeconfig: ${{ secrets.KUBE_CONFIG }}
           context: ""
 
-      - name: Create image pull secret
-        run: |
-          kubectl create secret docker-registry ghcr-cred \
-            --docker-server=ghcr.io \
-            --docker-username=${{ github.actor }} \
-            --docker-password=${{ secrets.GITHUB_TOKEN }} \
-            --docker-email=ci@github.com \
-            --dry-run=client -o yaml | kubectl apply -f -
-
       - name: Update Kubernetes Deployment
         run: |
           COMMIT_HASH=${{ env.commit_hash }}


### PR DESCRIPTION
remove: pull sectrects initialization because it is now handled explicitly when configuring the k8s secrects with explicit Personal Access Tokens in 1Password