### PR TITLE
feat/TD-23 include image as input

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,7 +33,15 @@ async function main() {
 
   // eslint-disable-next-line no-empty-pattern
   fastify.setSerializerCompiler(({}) => {
+    // eslint-disable-next-line no-unused-vars
     return (data) => JSON.stringify(data);
+  });
+
+  // This disables fastify's implicit logic validating and coercing the request body, because this is very error prone on complex schemas
+  // the validation is instead always done by the Zod schema
+  // eslint-disable-next-line no-empty-pattern
+  fastify.setValidatorCompiler(() => {
+    return () => true;
   });
 
   await initSwagger(fastify);

--- a/apps/api/src/llm-model/providers/ionos.ts
+++ b/apps/api/src/llm-model/providers/ionos.ts
@@ -54,6 +54,7 @@ export function constructIonosCompletionStreamFn(
         yield JSON.stringify(chunk);
       }
       // calculate the token usage manually as ionos does not return it
+      // TODO: add token count for image inputs. See guide for token count calculation https://platform.openai.com/docs/guides/images-vision?api-mode=responses&format=file
       const usage = calculateCompletionUsage({
         messages,
         modelMessage: { role: "assistant", content },

--- a/apps/api/src/llm-model/utils.ts
+++ b/apps/api/src/llm-model/utils.ts
@@ -33,14 +33,14 @@ function extractTextFromMessage(message: ChatCompletionMessageParam): string {
   if (typeof message.content === "string") {
     return message.content;
   }
-  
+
   if (Array.isArray(message.content)) {
     return message.content
       .filter((part) => part.type === "text")
       .map((part) => (part as any).text)
       .join(" ");
   }
-  
+
   return "";
 }
 

--- a/apps/api/src/llm-model/utils.ts
+++ b/apps/api/src/llm-model/utils.ts
@@ -27,7 +27,25 @@ export async function streamToController(
 }
 
 /**
- * Concatenates the prompt messages and the model’s final answer,
+ * Extracts text content from a message, handling both string and array content formats
+ */
+function extractTextFromMessage(message: ChatCompletionMessageParam): string {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  
+  if (Array.isArray(message.content)) {
+    return message.content
+      .filter((part) => part.type === "text")
+      .map((part) => (part as any).text)
+      .join(" ");
+  }
+  
+  return "";
+}
+
+/**
+ * Concatenates the prompt messages and the model's final answer,
  * then calculates token usage using the tiktoken library.
  * This is a HEURISTIC calculation and only exists due to IONOS
  * not sending a completion usage when requestion chat completion with streams enabled
@@ -47,12 +65,12 @@ export function calculateCompletionUsage({
 }): CompletionUsage {
   const enc = get_encoding("cl100k_base");
   try {
-    const promptText = messages.map((msg) => msg.content).join(" ");
+    const promptText = messages.map(extractTextFromMessage).join(" ");
     const promptTokens = enc.encode(promptText).length;
 
-    const completionText = modelMessage.content?.toString();
+    const completionText = extractTextFromMessage(modelMessage);
     const completionTokens =
-      completionText !== undefined ? enc.encode(completionText).length : 0;
+      completionText !== "" ? enc.encode(completionText).length : 0;
 
     return {
       prompt_tokens: promptTokens,

--- a/apps/api/src/routes/(app)/v1/chat/completions/post.ts
+++ b/apps/api/src/routes/(app)/v1/chat/completions/post.ts
@@ -46,7 +46,7 @@ const completionRequestSchema = z.object({
     }),
   ),
   max_tokens: z.number().optional().nullable(),
-  temperature: z.coerce.number().optional().default(1),
+  temperature: z.coerce.number().optional().default(0.4),
   stream: z.boolean().optional(),
 });
 
@@ -81,12 +81,12 @@ export async function handler(
     reply.send({ error: apiKeyError.message });
     return;
   }
-
+  
   if (apiKey === undefined) return;
 
   const requestParseResult = completionRequestSchema.safeParse(request.body);
   if (!requestParseResult.success) {
-    console.log("invalid request", JSON.stringify(request.body, null, 2));
+  
     reply
       .send({
         error: "Bad request",

--- a/apps/api/src/routes/(app)/v1/chat/completions/post.ts
+++ b/apps/api/src/routes/(app)/v1/chat/completions/post.ts
@@ -29,13 +29,13 @@ const imageUrlContentPartSchema = z.object({
   }),
 });
 
-const contentPartSchema = z.union([textContentPartSchema, imageUrlContentPartSchema]);
+const contentPartSchema = z.union([
+  textContentPartSchema,
+  imageUrlContentPartSchema,
+]);
 
 // Content can be either a string (legacy format) or an array of content parts (new format with image support)
-const messageContentSchema = z.union([
-  z.string(),
-  z.array(contentPartSchema),
-]);
+const messageContentSchema = z.union([z.string(), z.array(contentPartSchema)]);
 
 const completionRequestSchema = z.object({
   model: z.string(),
@@ -81,12 +81,11 @@ export async function handler(
     reply.send({ error: apiKeyError.message });
     return;
   }
-  
+
   if (apiKey === undefined) return;
 
   const requestParseResult = completionRequestSchema.safeParse(request.body);
   if (!requestParseResult.success) {
-  
     reply
       .send({
         error: "Bad request",
@@ -137,7 +136,6 @@ export async function handler(
       .status(404);
     return;
   }
-
 
   if (body.stream) {
     const completionStreamFn = getCompletionStreamFnByModel({ model });

--- a/apps/api/src/routes/(app)/v1/chat/completions/swagger-schemas.ts
+++ b/apps/api/src/routes/(app)/v1/chat/completions/swagger-schemas.ts
@@ -59,7 +59,54 @@ export const completionRequestSchemaSwagger = {
               type: "string",
               enum: ["system", "user", "assistant", "developer"],
             },
-            content: { type: "string" },
+            content: {
+              oneOf: [
+                {
+                  type: "string",
+                  description: "Text content (legacy format)"
+                },
+                {
+                  type: "array",
+                  description: "Array of content parts (supports text and images)",
+                  items: {
+                    oneOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          type: { type: "string", enum: ["text"] },
+                          text: { type: "string" }
+                        },
+                        required: ["type", "text"],
+                        description: "Text content part"
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: { type: "string", enum: ["image_url"] },
+                          image_url: {
+                            type: "object",
+                            properties: {
+                              url: { 
+                                type: "string",
+                                description: "URL of the image or base64 encoded image data (data:image/jpeg;base64,...)"
+                              },
+                              detail: { 
+                                type: "string", 
+                                enum: ["auto", "low", "high"],
+                                description: "Image detail level for processing"
+                              }
+                            },
+                            required: ["url"]
+                          }
+                        },
+                        required: ["type", "image_url"],
+                        description: "Image content part"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
           },
           required: ["role", "content"],
         },
@@ -69,6 +116,119 @@ export const completionRequestSchemaSwagger = {
       stream: { type: "boolean" },
     },
     required: ["model", "messages"],
+    examples: [
+      {
+        name: "Text-only request",
+        summary: "Text-only request",
+        description: "Basic chat completion with text content",
+        value: {
+          model: "gpt-4o-mini",
+          messages: [
+            {
+              role: "user",
+              content: "What is the capital of France?"
+            }
+          ],
+          max_tokens: 150,
+          temperature: 0.7,
+          stream: false
+        }
+      },
+      {
+        name: "Image analysis with URL",
+        summary: "Image analysis with URL",
+        description: "Chat completion with image input using image URL",
+        value: {
+          model: "gpt-4o-mini",
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: "What do you see in this image?"
+                },
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: "https://example.com/image.jpg",
+                    detail: "high"
+                  }
+                }
+              ]
+            }
+          ],
+          max_tokens: 300,
+          temperature: 0.7,
+          stream: false
+        }
+      },
+      {
+        name: "Image analysis with base64",
+        summary: "Image analysis with base64",
+        description: "Chat completion with base64 encoded image",
+        value: {
+          model: "gpt-4o-mini",
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: "Describe this chart and provide insights about the data trends."
+                },
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/...[truncated for example]",
+                    detail: "auto"
+                  }
+                }
+              ]
+            }
+          ],
+          max_tokens: 500,
+          temperature: 0.3,
+          stream: false
+        }
+      },
+      {
+        name: "Multiple images with analysis",
+        summary: "Multiple images with analysis",
+        description: "Chat completion analyzing multiple images",
+        value: {
+          model: "gpt-4o-mini",
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: "Compare these two images and tell me the differences."
+                },
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: "https://example.com/image1.jpg",
+                    detail: "high"
+                  }
+                },
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: "https://example.com/image2.jpg",
+                    detail: "high"
+                  }
+                }
+              ]
+            }
+          ],
+          max_tokens: 400,
+          temperature: 0.5,
+          stream: false
+        }
+      }
+    ]
   },
   security: [{ bearerAuth: [] }],
 };

--- a/apps/api/src/routes/(app)/v1/chat/completions/swagger-schemas.ts
+++ b/apps/api/src/routes/(app)/v1/chat/completions/swagger-schemas.ts
@@ -1,5 +1,7 @@
 import { SWAGGER_DEFAULT_RESPONSES_SCHEMA } from "@/swagger/const";
 
+// NOTE: This schema is for documentation purposes only
+// Actual validation is handled by Zod schemas in the route handlers
 export const completionRequestSchemaSwagger = {
   response: {
     200: {
@@ -63,21 +65,22 @@ export const completionRequestSchemaSwagger = {
               oneOf: [
                 {
                   type: "string",
-                  description: "Text content (legacy format)"
+                  description: "Text content (legacy format)",
                 },
                 {
                   type: "array",
-                  description: "Array of content parts (supports text and images)",
+                  description:
+                    "Array of content parts (supports text and images)",
                   items: {
                     oneOf: [
                       {
                         type: "object",
                         properties: {
                           type: { type: "string", enum: ["text"] },
-                          text: { type: "string" }
+                          text: { type: "string" },
                         },
                         required: ["type", "text"],
-                        description: "Text content part"
+                        description: "Text content part",
                       },
                       {
                         type: "object",
@@ -86,26 +89,28 @@ export const completionRequestSchemaSwagger = {
                           image_url: {
                             type: "object",
                             properties: {
-                              url: { 
+                              url: {
                                 type: "string",
-                                description: "URL of the image or base64 encoded image data (data:image/jpeg;base64,...)"
+                                description:
+                                  "URL of the image or base64 encoded image data (data:image/jpeg;base64,...)",
                               },
-                              detail: { 
-                                type: "string", 
+                              detail: {
+                                type: "string",
                                 enum: ["auto", "low", "high"],
-                                description: "Image detail level for processing"
-                              }
+                                description:
+                                  "Image detail level for processing",
+                              },
                             },
-                            required: ["url"]
-                          }
+                            required: ["url"],
+                          },
                         },
                         required: ["type", "image_url"],
-                        description: "Image content part"
-                      }
-                    ]
-                  }
-                }
-              ]
+                        description: "Image content part",
+                      },
+                    ],
+                  },
+                },
+              ],
             },
           },
           required: ["role", "content"],
@@ -118,50 +123,40 @@ export const completionRequestSchemaSwagger = {
     required: ["model", "messages"],
     examples: [
       {
-        name: "Text-only request",
-        summary: "Text-only request",
-        description: "Basic chat completion with text content",
-        value: {
-          model: "gpt-4o-mini",
-          messages: [
-            {
-              role: "user",
-              content: "What is the capital of France?"
-            }
-          ],
-          max_tokens: 150,
-          temperature: 0.7,
-          stream: false
-        }
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "user",
+            content: "What is the capital of France?",
+          },
+        ],
+        max_tokens: 150,
+        temperature: 0.7,
+        stream: false,
       },
       {
-        name: "Image analysis with URL",
-        summary: "Image analysis with URL",
-        description: "Chat completion with image input using image URL",
-        value: {
-          model: "gpt-4o-mini",
-          messages: [
-            {
-              role: "user",
-              content: [
-                {
-                  type: "text",
-                  text: "What do you see in this image?"
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "What do you see in this image?",
+              },
+              {
+                type: "image_url",
+                image_url: {
+                  url: "https://fastly.picsum.photos/id/689/200/300.jpg?hmac=vg64_CHvD_VwWyxzKJAAAZswOJG8_8xEdMcP9BHgLJM",
+                  detail: "low",
                 },
-                {
-                  type: "image_url",
-                  image_url: {
-                    url: "https://example.com/image.jpg",
-                    detail: "high"
-                  }
-                }
-              ]
-            }
-          ],
-          max_tokens: 300,
-          temperature: 0.7,
-          stream: false
-        }
+              },
+            ],
+          },
+        ],
+        max_tokens: 300,
+        temperature: 0.7,
+        stream: false,
       },
       {
         name: "Image analysis with base64",
@@ -175,60 +170,55 @@ export const completionRequestSchemaSwagger = {
               content: [
                 {
                   type: "text",
-                  text: "Describe this chart and provide insights about the data trends."
+                  text: "Describe this chart and provide insights about the data trends.",
                 },
                 {
                   type: "image_url",
                   image_url: {
                     url: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/...[truncated for example]",
-                    detail: "auto"
-                  }
-                }
-              ]
-            }
+                    detail: "auto",
+                  },
+                },
+              ],
+            },
           ],
           max_tokens: 500,
           temperature: 0.3,
-          stream: false
-        }
+          stream: false,
+        },
       },
       {
-        name: "Multiple images with analysis",
-        summary: "Multiple images with analysis",
-        description: "Chat completion analyzing multiple images",
-        value: {
-          model: "gpt-4o-mini",
-          messages: [
-            {
-              role: "user",
-              content: [
-                {
-                  type: "text",
-                  text: "Compare these two images and tell me the differences."
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Compare these two images and tell me the differences.",
+              },
+              {
+                type: "image_url",
+                image_url: {
+                  url: "https://example.com/image1.jpg",
+                  detail: "high",
                 },
-                {
-                  type: "image_url",
-                  image_url: {
-                    url: "https://example.com/image1.jpg",
-                    detail: "high"
-                  }
+              },
+              {
+                type: "image_url",
+                image_url: {
+                  url: "https://example.com/image2.jpg",
+                  detail: "high",
                 },
-                {
-                  type: "image_url",
-                  image_url: {
-                    url: "https://example.com/image2.jpg",
-                    detail: "high"
-                  }
-                }
-              ]
-            }
-          ],
-          max_tokens: 400,
-          temperature: 0.5,
-          stream: false
-        }
-      }
-    ]
+              },
+            ],
+          },
+        ],
+        max_tokens: 400,
+        temperature: 0.5,
+        stream: false,
+      },
+    ],
   },
   security: [{ bearerAuth: [] }],
 };

--- a/apps/api/src/routes/(app)/v1/chat/completions/swagger-schemas.ts
+++ b/apps/api/src/routes/(app)/v1/chat/completions/swagger-schemas.ts
@@ -220,5 +220,8 @@ export const completionRequestSchemaSwagger = {
       },
     ],
   },
+  summary: "Chat completion",
+  description:
+    "proxy for openai compatible chat completion the standard is not fully implemented. Supports text input and image input. Image input is not supported for all models. If a model does not support image input, the request will fail with a generic 400 error. See examples for usage. example1 generic text usage, exampe 2-4 image usage. Usage is metered by the api key and the associated project. If the buget is exceeds the limit, the request will fail with a 429 error.",
   security: [{ bearerAuth: [] }],
 };

--- a/apps/api/src/routes/(app)/v1/embeddings/swagger-schemas.ts
+++ b/apps/api/src/routes/(app)/v1/embeddings/swagger-schemas.ts
@@ -28,4 +28,7 @@ export const embeddingRequestSwaggerSchema = {
     required: ["model", "input"],
   },
   security: [{ bearerAuth: [] }],
+  summary: "Create embeddings for the given model and input of size 1024",
+  description:
+    "create embeddings for the given model and input. Supports batch-embedding. The input is an array of strings, type string as input is not supported. The embeddings are returned as an array of numbers the size is ALWAYS 1024. The embeddings are metered by the api key and the associated project. If the buget is exceeds the limit, the request will fail with a 429 error.",
 };

--- a/apps/api/src/routes/(app)/v1/models/swagger-schema.ts
+++ b/apps/api/src/routes/(app)/v1/models/swagger-schema.ts
@@ -28,5 +28,8 @@ export const modelRequestSwaggerSchema: FastifySchema = {
     },
     ...SWAGGER_DEFAULT_RESPONSES_SCHEMA,
   },
+  summary: "List models for the current api key and project",
+  description:
+    "list the models as objects with the following properties: id, name, createdAt, provider, displayName, description, pricingData",
   security: [{ bearerAuth: [] }],
 };

--- a/apps/api/src/routes/(app)/v1/usage/swagger-schemas.ts
+++ b/apps/api/src/routes/(app)/v1/usage/swagger-schemas.ts
@@ -13,4 +13,7 @@ export const usageRequestSwaggerSchema = {
     ...SWAGGER_DEFAULT_RESPONSES_SCHEMA,
   },
   security: [{ bearerAuth: [] }],
+  summary: "Get the remaining limit for the current api key and project",
+  description:
+    "get the remaining limit for the current api key and project in cents. The limit is the total amount of money that can be spent on the api key and project. The limit is reset at the beginning of the month.",
 };

--- a/apps/api/src/swagger/schemas.ts
+++ b/apps/api/src/swagger/schemas.ts
@@ -13,21 +13,22 @@ export const completionSchema = {
               oneOf: [
                 {
                   type: "string",
-                  description: "Text content (legacy format)"
+                  description: "Text content (legacy format)",
                 },
                 {
                   type: "array",
-                  description: "Array of content parts (supports text and images)",
+                  description:
+                    "Array of content parts (supports text and images)",
                   items: {
                     oneOf: [
                       {
                         type: "object",
                         properties: {
                           type: { type: "string", enum: ["text"] },
-                          text: { type: "string" }
+                          text: { type: "string" },
                         },
                         required: ["type", "text"],
-                        description: "Text content part"
+                        description: "Text content part",
                       },
                       {
                         type: "object",
@@ -36,26 +37,28 @@ export const completionSchema = {
                           image_url: {
                             type: "object",
                             properties: {
-                              url: { 
+                              url: {
                                 type: "string",
-                                description: "URL of the image or base64 encoded image data (data:image/jpeg;base64,...)"
+                                description:
+                                  "URL of the image or base64 encoded image data (data:image/jpeg;base64,...)",
                               },
-                              detail: { 
-                                type: "string", 
+                              detail: {
+                                type: "string",
                                 enum: ["auto", "low", "high"],
-                                description: "Image detail level for processing"
-                              }
+                                description:
+                                  "Image detail level for processing",
+                              },
                             },
-                            required: ["url"]
-                          }
+                            required: ["url"],
+                          },
                         },
                         required: ["type", "image_url"],
-                        description: "Image content part"
-                      }
-                    ]
-                  }
-                }
-              ]
+                        description: "Image content part",
+                      },
+                    ],
+                  },
+                },
+              ],
             },
           },
           required: ["role", "content"],

--- a/apps/api/src/swagger/schemas.ts
+++ b/apps/api/src/swagger/schemas.ts
@@ -9,7 +9,54 @@ export const completionSchema = {
           type: "object",
           properties: {
             role: { type: "string", enum: ["system", "user", "assistant"] },
-            content: { type: "string" },
+            content: {
+              oneOf: [
+                {
+                  type: "string",
+                  description: "Text content (legacy format)"
+                },
+                {
+                  type: "array",
+                  description: "Array of content parts (supports text and images)",
+                  items: {
+                    oneOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          type: { type: "string", enum: ["text"] },
+                          text: { type: "string" }
+                        },
+                        required: ["type", "text"],
+                        description: "Text content part"
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: { type: "string", enum: ["image_url"] },
+                          image_url: {
+                            type: "object",
+                            properties: {
+                              url: { 
+                                type: "string",
+                                description: "URL of the image or base64 encoded image data (data:image/jpeg;base64,...)"
+                              },
+                              detail: { 
+                                type: "string", 
+                                enum: ["auto", "low", "high"],
+                                description: "Image detail level for processing"
+                              }
+                            },
+                            required: ["url"]
+                          }
+                        },
+                        required: ["type", "image_url"],
+                        description: "Image content part"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
           },
           required: ["role", "content"],
         },


### PR DESCRIPTION
## Support multi-modal chat messages (text & images) in completions API

Ticket Reference: [TD-23](https://fwu-de.atlassian.net/browse/TD-23)

---

- Add support for chat messages containing both text and image parts (including URLs and base64 images) via schema updates and input validation
 - Update Zod and Swagger schemas to document and validate new message format
- Introduce helper for extracting text from mixed-format messages
- Update usage calculation and handler to support new input structure
- Adjust examples and docs for image input usage


[TD-23]: https://fwu-de.atlassian.net/browse/TD-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ