### PR TITLE
fix: not terminating stream for inappropiate content / not returning the correct status code

### DIFF
--- a/apps/api/src/llm-model/providers/ionos.ts
+++ b/apps/api/src/llm-model/providers/ionos.ts
@@ -125,6 +125,17 @@ export function constructIonosEmbeddingFn(llmModel: LlmModel) {
     usage: CompletionUsage;
     model: string;
   }> {
+    if (input.length === 0) {
+      return {
+        data: [],
+        usage: {
+          prompt_tokens: 0,
+          total_tokens: 0,
+          completion_tokens: 0,
+        },
+        model: llmModel.name,
+      };
+    }
     const { data, usage } = await client.embeddings.create({ input, model });
     return {
       data,

--- a/apps/api/src/routes/(app)/v1/admin/organizations/$organizationId/report/get.ts
+++ b/apps/api/src/routes/(app)/v1/admin/organizations/$organizationId/report/get.ts
@@ -29,9 +29,9 @@ export async function handler(
 
   if (format === "csv") {
     const csvString = convertToCSV(report);
-    reply.send(csvString).status(200);
+    reply.status(200).send(csvString);
     return;
   }
 
-  return reply.send({ report }).status(200);
+  return reply.status(200).send({ report });
 }

--- a/apps/api/src/routes/(app)/v1/admin/organizations/get.ts
+++ b/apps/api/src/routes/(app)/v1/admin/organizations/get.ts
@@ -12,5 +12,5 @@ export async function handler(
 
   const organizations = await dbGetAllOrganizations();
 
-  return reply.send({ organizations }).status(200);
+  return reply.status(200).send({ organizations });
 }

--- a/apps/api/src/routes/(app)/v1/chat/completions/post.ts
+++ b/apps/api/src/routes/(app)/v1/chat/completions/post.ts
@@ -185,7 +185,6 @@ export async function handler(
             ),
           );
           controller.enqueue(new TextEncoder().encode("[DONE]\n\n"));
-          //controller.error(new Error("Inappropriate content or other error"));
           controller.close();
         },
       });

--- a/apps/api/src/routes/(app)/v1/chat/completions/post.ts
+++ b/apps/api/src/routes/(app)/v1/chat/completions/post.ts
@@ -2,7 +2,7 @@ import {
   getCompletionFnByModel,
   getCompletionStreamFnByModel,
 } from "@/llm-model/providers";
-import { validateApiKeyWithResult } from "@/routes/utils";
+import { getContentFilterFailedChunk, validateApiKeyWithResult } from "@/routes/utils";
 import {
   ApiKeyModel,
   checkLimitsByApiKeyIdWithResult,
@@ -15,22 +15,6 @@ import { ChatCompletionMessageParam } from "openai/resources/chat/completions.mj
 import { CompletionUsage } from "openai/resources/completions.mjs";
 import { z } from "zod";
 
-const safetyCheckFailedChunk = {
-  choices: [
-    {
-      index: 0,
-      delta: {
-        content:
-          "Die Anfrage wurde wegen unangemessener Inhalte automatisch blockiert.",
-      },
-    },
-  ],
-  object: "chat.completion.chunk",
-  usage: {
-    prompt_tokens: 0,
-    completion_tokens: 0,
-  },
-};
 
 // Define content part schemas for image and text
 const textContentPartSchema = z.object({
@@ -60,7 +44,7 @@ const completionRequestSchema = z.object({
     z.object({
       role: z.enum(["system", "user", "assistant", "developer"]),
       content: messageContentSchema,
-    }),
+    })
   ),
   max_tokens: z.number().optional().nullable(),
   temperature: z.coerce.number().optional().default(0.4),
@@ -90,7 +74,7 @@ async function onUsageCallback({
 
 export async function handler(
   request: FastifyRequest,
-  reply: FastifyReply,
+  reply: FastifyReply
 ): Promise<void> {
   const [apiKeyError, apiKey] = await validateApiKeyWithResult(request, reply);
 
@@ -138,7 +122,7 @@ export async function handler(
       ? availableModels.find((model) => model.name === body.model)
       : availableModels.find(
           (model) =>
-            model.name === body.model && model.provider === maybeProviderHeader,
+            model.name === body.model && model.provider === maybeProviderHeader
         );
 
   if (model === undefined) {
@@ -176,14 +160,27 @@ export async function handler(
         },
       });
     } catch (error) {
-      console.log("Error processing stream stream:", error);
+      // Check if error has a code field and evaluate its value not all providers have a code field
+      const errorCode = error instanceof Error && 'code' in error ? (error as any).code : undefined;
+      
+      const contentFilterTriggered = errorCode === 'content_filter';
+      
+      console.error('Error processing stream:', {
+        errorCode,
+        contentFilterTriggered,
+        message: error instanceof Error ? error.message : 'Unknown error'
+      });
+      
       stream = new ReadableStream({
         start(controller) {
-          controller.enqueue(
-            new TextEncoder().encode(
-              JSON.stringify(safetyCheckFailedChunk) + "\n\n",
-            ),
-          );
+          if (contentFilterTriggered) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                JSON.stringify(getContentFilterFailedChunk({id: crypto.randomUUID(), created: Date.now(), model: model.name})) + "\n\n"
+              )
+            );
+          }
+          // Always send [DONE] to close the stream properly
           controller.enqueue(new TextEncoder().encode("[DONE]\n\n"));
           controller.close();
         },

--- a/apps/api/src/routes/(app)/v1/models/get.ts
+++ b/apps/api/src/routes/(app)/v1/models/get.ts
@@ -13,5 +13,5 @@ export async function handler(
 
   const models = await dbGetModelsByApiKeyId({ apiKeyId: apiKey.id });
 
-  reply.send(obscureModels(models)).status(200);
+  reply.status(200).send(obscureModels(models));
 }

--- a/apps/api/src/routes/(app)/v1/usage/get.ts
+++ b/apps/api/src/routes/(app)/v1/usage/get.ts
@@ -20,12 +20,10 @@ export async function handler(
   });
 
   if (error !== null) {
-    reply
-      .send({
-        error: "Something went wrong while calculating the usage",
-        details: error.message,
-      })
-      .status(500);
+    reply.status(500).send({
+      error: "Something went wrong while calculating the usage",
+      details: error.message,
+    });
     return;
   }
 
@@ -34,7 +32,7 @@ export async function handler(
     _remainingLimitInCent > 0 ? _remainingLimitInCent : 0;
 
   reply
-    .send({ remainingLimitInCent, limitInCent: apiKey.limitInCent })
-    .status(200);
+    .status(200)
+    .send({ remainingLimitInCent, limitInCent: apiKey.limitInCent });
   return;
 }

--- a/apps/api/src/routes/utils.ts
+++ b/apps/api/src/routes/utils.ts
@@ -44,14 +44,22 @@ export async function validateApiKey(
   return apiKeyValidationResponse.apiKey;
 }
 
-
-export function getContentFilterFailedChunk({id, created, model}: {id: string, created: number, model: string}): ChatCompletionChunk {
+export function getContentFilterFailedChunk({
+  id,
+  created,
+  model,
+}: {
+  id: string;
+  created: number;
+  model: string;
+}): ChatCompletionChunk {
   return {
     choices: [
       {
         index: 0,
         delta: {
-          content: "Die Anfrage wurde wegen unangemessener Inhalte automatisch blockiert.",
+          content:
+            "Die Anfrage wurde wegen unangemessener Inhalte automatisch blockiert.",
         },
         finish_reason: "content_filter",
       },

--- a/apps/api/src/routes/utils.ts
+++ b/apps/api/src/routes/utils.ts
@@ -1,6 +1,7 @@
 import { ApiKeyModel, dbValidateApiKey } from "@dgpt/db";
 import { errorifyAsyncFn } from "@dgpt/utils";
 import { FastifyReply, FastifyRequest } from "fastify";
+import { ChatCompletionChunk } from "openai/resources/chat/completions.mjs";
 
 const BEARER_PREFIX = "Bearer ";
 
@@ -41,4 +42,23 @@ export async function validateApiKey(
   }
 
   return apiKeyValidationResponse.apiKey;
+}
+
+
+export function getContentFilterFailedChunk({id, created, model}: {id: string, created: number, model: string}): ChatCompletionChunk {
+  return {
+    choices: [
+      {
+        index: 0,
+        delta: {
+          content: "Die Anfrage wurde wegen unangemessener Inhalte automatisch blockiert.",
+        },
+        finish_reason: "content_filter",
+      },
+    ],
+    id,
+    created,
+    model,
+    object: "chat.completion.chunk",
+  };
 }

--- a/apps/api/src/swagger/index.ts
+++ b/apps/api/src/swagger/index.ts
@@ -41,7 +41,14 @@ export async function initSwagger(fastify: FastifyInstance) {
       // docExpansion: "none",
       deepLinking: false,
     },
-    staticCSP: true,
+    staticCSP: {
+      "default-src": ["'none'"],
+      "connect-src": ["'self'", "127.0.0.1", "localhost"],
+      "style-src": ["'self'", "'unsafe-inline'", "https:"],
+      "script-src": ["'self'"],
+      "img-src": ["'self'", "data:", "https:"],
+      "font-src": ["'self'", "https:"],
+    },
     transformSpecification: (swaggerObject) => swaggerObject,
   });
 }

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -54,7 +54,7 @@ const DEFAULT_MODELS: LlmInsertModel[] = [
     organizationId: ORGANIZATION_ID,
   },
   {
-    id: "0c4d9640-549c-43a5-815d-c80512a8e7e2",
+    id: "9578ed80-b0c2-4968-b253-d897576e5512",
     provider: "azure",
     name: "gpt-4o-mini",
     displayName: "OpenAI GPT-4o Mini",

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -17,9 +17,10 @@ const PROJECT_ID = "test-project-0";
 const API_KEY_NAME = "Test API Key";
 // All prices are rough estimates, probably outdated and just for mocking purposes
 // Static ids are used to ensure that the models are not created again
+// the ids are taken from the staging/production database for interoperability to be able to connect to local telli api or staging
 const DEFAULT_MODELS: LlmInsertModel[] = [
   {
-    id: "1c4485dd-2f5e-4288-ab53-afa236ee659b",
+    id: "b870b74d-7458-4dcf-99f6-ace83ef514f4",
     provider: "ionos",
     name: "BAAI/bge-m3",
     displayName: "IONOS BGE M3",
@@ -35,7 +36,7 @@ const DEFAULT_MODELS: LlmInsertModel[] = [
     organizationId: ORGANIZATION_ID,
   },
   {
-    id: "5a3e3184-f0c1-4dee-8821-1bbd1f1e5ea6",
+    id: "7dcb063f-5241-4846-b11f-a621ea1dd4a9",
     provider: "ionos",
     name: "meta-llama/Meta-Llama-3.1-8B-Instruct",
     displayName: "IONOS Llama 3 8B Instruct",
@@ -53,7 +54,7 @@ const DEFAULT_MODELS: LlmInsertModel[] = [
     organizationId: ORGANIZATION_ID,
   },
   {
-    id: "9e51dda7-0b5c-4fec-a3fc-19836cad702d",
+    id: "0c4d9640-549c-43a5-815d-c80512a8e7e2",
     provider: "azure",
     name: "gpt-4o-mini",
     displayName: "OpenAI GPT-4o Mini",


### PR DESCRIPTION
standardize response handling and improve error management across endpoints

- Implement consistent response structure by using `reply.status().send()` in various endpoints. Otherwise it will erroneously always send a statusCode 200 back.
- Add early return for empty input in the Ionos embedding function to prevent error from empty input.
- Update completion endpoint to gracefully end the stream on error, due to azure throwing one when inappropiate content is detected
- Update database seed with new model IDs to prevent conflicts when working locally and with staging.