### PR TITLE
Costs Refactoring (part 1)

### DIFF
--- a/apps/api/src/llm-model/providers/openai.ts
+++ b/apps/api/src/llm-model/providers/openai.ts
@@ -16,9 +16,6 @@ export function constructOpenAiCompletionStreamFn(
 
   const client = new OpenAI({
     apiKey: model.setting.apiKey,
-    defaultHeaders: {
-      Authorization: `Bearer ${model.setting.apiKey}`,
-    },
     baseURL: model.setting.baseUrl,
   });
 
@@ -59,9 +56,6 @@ export function constructOpenAiCompletionFn(model: LlmModel): CompletionFn {
 
   const client = new OpenAI({
     apiKey: model.setting.apiKey,
-    defaultHeaders: {
-      Authorization: `Bearer ${model.setting.apiKey}`,
-    },
     baseURL: model.setting.baseUrl,
   });
 

--- a/apps/api/src/routes/(app)/v1/chat/completions/post.ts
+++ b/apps/api/src/routes/(app)/v1/chat/completions/post.ts
@@ -121,19 +121,11 @@ export async function handler(
   }
 
   const availableModels = await dbGetModelsByApiKeyId({ apiKeyId: apiKey.id });
-
-  const maybeProviderHeader = request.headers["x-llm-provider"];
-  const model =
-    maybeProviderHeader === undefined
-      ? availableModels.find((model) => model.name === body.model)
-      : availableModels.find(
-          (model) =>
-            model.name === body.model && model.provider === maybeProviderHeader,
-        );
+  const model = availableModels.find((model) => model.name === body.model);
 
   if (model === undefined) {
     reply.status(404).send({
-      error: `No model with name ${body.model} found.${maybeProviderHeader !== undefined ? ` Requested Provider: ${maybeProviderHeader}` : ""}`,
+      error: `No model with name ${body.model} found.`,
     });
     return;
   }

--- a/apps/api/src/routes/(app)/v1/embeddings/post.ts
+++ b/apps/api/src/routes/(app)/v1/embeddings/post.ts
@@ -61,19 +61,11 @@ export async function handler(
   const body = requestParseResult.data;
 
   const availableModels = await dbGetModelsByApiKeyId({ apiKeyId: apiKey.id });
-
-  const maybeProviderHeader = request.headers["x-llm-provider"];
-  const model =
-    maybeProviderHeader === undefined
-      ? availableModels.find((model) => model.name === body.model)
-      : availableModels.find(
-          (model) =>
-            model.name === body.model && model.provider === maybeProviderHeader,
-        );
+  const model = availableModels.find((model) => model.name === body.model);
 
   if (model === undefined) {
     reply.status(404).send({
-      error: `No model with name ${body.model} found.${maybeProviderHeader !== undefined ? ` Requested Provider: ${maybeProviderHeader}` : ""}`,
+      error: `No model with name ${body.model} found.`,
     });
     return;
   }

--- a/apps/api/src/routes/(app)/v1/images/generations/post.ts
+++ b/apps/api/src/routes/(app)/v1/images/generations/post.ts
@@ -79,19 +79,11 @@ export async function handler(
   const body = requestParseResult.data;
 
   const availableModels = await dbGetModelsByApiKeyId({ apiKeyId: apiKey.id });
-
-  const maybeProviderHeader = request.headers["x-llm-provider"];
-  const model =
-    maybeProviderHeader === undefined
-      ? availableModels.find((model) => model.name === body.model)
-      : availableModels.find(
-          (model) =>
-            model.name === body.model && model.provider === maybeProviderHeader,
-        );
+  const model = availableModels.find((model) => model.name === body.model);
 
   if (model === undefined) {
     reply.status(404).send({
-      error: `No model with name ${body.model} found.${maybeProviderHeader !== undefined ? ` Requested Provider: ${maybeProviderHeader}` : ""}`,
+      error: `No model with name ${body.model} found.`,
     });
     return;
   }

--- a/packages/database/migrations/0003_graceful_goblin_queen.sql
+++ b/packages/database/migrations/0003_graceful_goblin_queen.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "completion_usage_tracking" ADD COLUMN "costs_in_cent" real DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "image_generation_usage_tracking" ADD COLUMN "costs_in_cent" real DEFAULT 0 NOT NULL;

--- a/packages/database/migrations/meta/0003_snapshot.json
+++ b/packages/database/migrations/meta/0003_snapshot.json
@@ -1,0 +1,619 @@
+{
+  "id": "41cca0b3-01bb-45fc-a0f9-fea94fda8470",
+  "prevId": "35495a1c-2e25-47c1-8684-faf21e7d2e58",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin": {
+      "name": "admin",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_email_unique": {
+          "name": "admin_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "api_key_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "limit_in_cent": {
+          "name": "limit_in_cent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "previousBudgets": {
+          "name": "previousBudgets",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_project_id_project_id_fk": {
+          "name": "api_key_project_id_project_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.completion_usage_tracking": {
+      "name": "completion_usage_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costs_in_cent": {
+          "name": "costs_in_cent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "completion_usage_tracking_model_id_llm_model_id_fk": {
+          "name": "completion_usage_tracking_model_id_llm_model_id_fk",
+          "tableFrom": "completion_usage_tracking",
+          "tableTo": "llm_model",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "completion_usage_tracking_api_key_id_api_key_id_fk": {
+          "name": "completion_usage_tracking_api_key_id_api_key_id_fk",
+          "tableFrom": "completion_usage_tracking",
+          "tableTo": "api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "completion_usage_tracking_project_id_project_id_fk": {
+          "name": "completion_usage_tracking_project_id_project_id_fk",
+          "tableFrom": "completion_usage_tracking",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.image_generation_usage_tracking": {
+      "name": "image_generation_usage_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number_of_images": {
+          "name": "number_of_images",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costs_in_cent": {
+          "name": "costs_in_cent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "image_generation_usage_tracking_model_id_llm_model_id_fk": {
+          "name": "image_generation_usage_tracking_model_id_llm_model_id_fk",
+          "tableFrom": "image_generation_usage_tracking",
+          "tableTo": "llm_model",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "image_generation_usage_tracking_api_key_id_api_key_id_fk": {
+          "name": "image_generation_usage_tracking_api_key_id_api_key_id_fk",
+          "tableFrom": "image_generation_usage_tracking",
+          "tableTo": "api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "image_generation_usage_tracking_project_id_project_id_fk": {
+          "name": "image_generation_usage_tracking_project_id_project_id_fk",
+          "tableFrom": "image_generation_usage_tracking",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_model_api_key_mapping": {
+      "name": "llm_model_api_key_mapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "llm_model_id": {
+          "name": "llm_model_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "llm_model_api_key_mapping_llm_model_id_llm_model_id_fk": {
+          "name": "llm_model_api_key_mapping_llm_model_id_llm_model_id_fk",
+          "tableFrom": "llm_model_api_key_mapping",
+          "tableTo": "llm_model",
+          "columnsFrom": [
+            "llm_model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "llm_model_api_key_mapping_api_key_id_api_key_id_fk": {
+          "name": "llm_model_api_key_mapping_api_key_id_api_key_id_fk",
+          "tableFrom": "llm_model_api_key_mapping",
+          "tableTo": "api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_model": {
+      "name": "llm_model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_metada": {
+          "name": "price_metada",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "supported_image_formats": {
+          "name": "supported_image_formats",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "llm_model_organization_id_organization_id_fk": {
+          "name": "llm_model_organization_id_organization_id_fk",
+          "tableFrom": "llm_model",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_in_cent": {
+          "name": "limit_in_cent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "previousBudgets": {
+          "name": "previousBudgets",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.api_key_state": {
+      "name": "api_key_state",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deleted"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1752706451859,
       "tag": "0002_previous_wither",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1753309651963,
+      "tag": "0003_graceful_goblin_queen",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -10,6 +10,7 @@
     "db:generate": "dotenv -e ../../.env -- drizzle-kit generate",
     "db:migrate": "dotenv -e ../../.env -- drizzle-kit migrate --config=./drizzle.config.ts",
     "db:seed": "dotenv -e ../../.env -- tsx src/seed.ts",
+    "db:calculate-costs": "dotenv -e ../../.env -- tsx src/scripts/calculate-existing-costs.ts",
     "types": "tsc --noEmit",
     "lint": "eslint \"**/*.ts*\" --max-warnings 0"
   },

--- a/packages/database/src/functions/completion-usage.ts
+++ b/packages/database/src/functions/completion-usage.ts
@@ -2,15 +2,52 @@ import { db } from "..";
 import {
   CompletionUsageInsertModel,
   completionUsageTrackingTable,
+  llmModelTable,
 } from "../schema";
+import { eq } from "drizzle-orm";
+import {
+  calculatePriceInCentByTextModelAndUsage,
+  calculatePriceInCentByEmbeddingModelAndUsage,
+} from "@dgpt/llm-model";
 
 export async function dbCreateCompletionUsage(
   completionUsage: CompletionUsageInsertModel,
 ) {
+  // Get the model to calculate costs
+  const model = await db
+    .select()
+    .from(llmModelTable)
+    .where(eq(llmModelTable.id, completionUsage.modelId))
+    .limit(1);
+
+  if (model.length === 0) {
+    throw new Error(`Model not found: ${completionUsage.modelId}`);
+  }
+
+  const modelData = model[0]!;
+  let costsInCent = 0;
+
+  // Calculate costs based on model price metadata
+  if (modelData.priceMetadata.type === "text") {
+    costsInCent = calculatePriceInCentByTextModelAndUsage({
+      priceMetadata: modelData.priceMetadata,
+      promptTokens: completionUsage.promptTokens,
+      completionTokens: completionUsage.completionTokens,
+    });
+  } else if (modelData.priceMetadata.type === "embedding") {
+    costsInCent = calculatePriceInCentByEmbeddingModelAndUsage({
+      priceMetadata: modelData.priceMetadata,
+      promptTokens: completionUsage.promptTokens,
+    });
+  }
+
   const insertedCompletionUsage = (
     await db
       .insert(completionUsageTrackingTable)
-      .values(completionUsage)
+      .values({
+        ...completionUsage,
+        costsInCent,
+      })
       .returning()
   )[0];
 

--- a/packages/database/src/functions/image-generation-usage.ts
+++ b/packages/database/src/functions/image-generation-usage.ts
@@ -2,15 +2,43 @@ import { db } from "..";
 import {
   ImageGenerationUsageInsertModel,
   imageGenerationUsageTrackingTable,
+  llmModelTable,
 } from "../schema";
+import { eq } from "drizzle-orm";
+import { calculatePriceInCentByImageModelAndUsage } from "@dgpt/llm-model";
 
 export async function dbCreateImageGenerationUsage(
   imageGenerationUsage: ImageGenerationUsageInsertModel,
 ) {
+  // Get the model to calculate costs
+  const model = await db
+    .select()
+    .from(llmModelTable)
+    .where(eq(llmModelTable.id, imageGenerationUsage.modelId))
+    .limit(1);
+
+  if (model.length === 0) {
+    throw new Error(`Model not found: ${imageGenerationUsage.modelId}`);
+  }
+
+  const modelData = model[0]!;
+  let costsInCent = 0;
+
+  // Calculate costs based on model price metadata
+  if (modelData.priceMetadata.type === "image") {
+    costsInCent = calculatePriceInCentByImageModelAndUsage({
+      priceMetadata: modelData.priceMetadata,
+      numberOfImages: imageGenerationUsage.numberOfImages,
+    });
+  }
+
   const insertedImageGenerationUsage = (
     await db
       .insert(imageGenerationUsageTrackingTable)
-      .values(imageGenerationUsage)
+      .values({
+        ...imageGenerationUsage,
+        costsInCent,
+      })
       .returning()
   )[0];
 

--- a/packages/database/src/functions/limit.ts
+++ b/packages/database/src/functions/limit.ts
@@ -2,14 +2,13 @@ import {
   getStartOfCurrentMonth,
   getEndOfCurrentMonth,
   errorifyAsyncFn,
-  getNumberOrDefault,
 } from "@dgpt/utils";
-import { ApiKeyModel, db, dbGetApiKeyById, dbGetModelsByIds } from "..";
-import { sql } from "drizzle-orm";
+import { ApiKeyModel, db, dbGetApiKeyById } from "..";
+import { and, between, eq, sum } from "drizzle-orm";
 import {
-  calculatePriceInCentByTextModelAndUsage,
-  calculatePriceInCentByImageModelAndUsage,
-} from "@dgpt/llm-model";
+  completionUsageTrackingTable,
+  imageGenerationUsageTrackingTable,
+} from "../schema";
 
 export const checkLimitsByApiKeyIdWithResult = errorifyAsyncFn(
   checkLimitsByApiKeyId,
@@ -54,173 +53,35 @@ export async function getUsageInCentByApiKeyId({
     throw Error("Could not find api key");
   }
 
-  const chatCompletionUsages = await dbGetChatCompletionUsageByApiKeyId({
-    apiKeyId,
-    startDate,
-    endDate,
-  });
+  // Get total costs from completion usage
+  const completionCosts = await db
+    .select({ totalCosts: sum(completionUsageTrackingTable.costsInCent) })
+    .from(completionUsageTrackingTable)
+    .where(
+      and(
+        eq(completionUsageTrackingTable.apiKeyId, apiKeyId),
+        between(completionUsageTrackingTable.createdAt, startDate, endDate),
+      ),
+    );
 
-  const imageGenerationUsages = await dbGetImageGenerationUsageByApiKeyId({
-    apiKeyId,
-    startDate,
-    endDate,
-  });
+  // Get total costs from image generation usage
+  const imageCosts = await db
+    .select({ totalCosts: sum(imageGenerationUsageTrackingTable.costsInCent) })
+    .from(imageGenerationUsageTrackingTable)
+    .where(
+      and(
+        eq(imageGenerationUsageTrackingTable.apiKeyId, apiKeyId),
+        between(
+          imageGenerationUsageTrackingTable.createdAt,
+          startDate,
+          endDate,
+        ),
+      ),
+    );
 
-  const allModelIds = [
-    ...chatCompletionUsages.map((m) => m.modelId),
-    ...imageGenerationUsages.map((m) => m.modelId),
-  ];
+  const completionTotal = completionCosts[0]?.totalCosts || 0;
+  const imageTotal = imageCosts[0]?.totalCosts || 0;
+  const actualPrice = Number(completionTotal) + Number(imageTotal);
 
-  const models = await dbGetModelsByIds({
-    modelIds: allModelIds,
-  });
-
-  let priceInCent = 0;
-
-  // Calculate price for text models
-  for (const modelUsage of chatCompletionUsages) {
-    const maybeModel = models.find((m) => m.id === modelUsage.modelId);
-
-    if (maybeModel === undefined) {
-      console.warn(`Could not find model with id ${modelUsage.modelId}`);
-      continue;
-    }
-
-    if (maybeModel.priceMetadata.type === "text") {
-      const modelPrice = calculatePriceInCentByTextModelAndUsage({
-        priceMetadata: maybeModel.priceMetadata,
-        promptTokens: modelUsage.promptTokens,
-        completionTokens: modelUsage.completionTokens,
-      });
-      priceInCent += modelPrice;
-    }
-  }
-
-  // Calculate price for image models
-  for (const imageUsage of imageGenerationUsages) {
-    const maybeModel = models.find((m) => m.id === imageUsage.modelId);
-
-    if (maybeModel === undefined) {
-      console.warn(`Could not find model with id ${imageUsage.modelId}`);
-      continue;
-    }
-
-    if (maybeModel.priceMetadata.type === "image") {
-      const modelPrice = calculatePriceInCentByImageModelAndUsage({
-        priceMetadata: maybeModel.priceMetadata,
-        numberOfImages: imageUsage.numberOfImages,
-      });
-      priceInCent += modelPrice;
-    }
-  }
-
-  return { apiKey, actualPrice: priceInCent };
-}
-
-type Interval =
-  | "hour"
-  | "minute"
-  | "day"
-  | "week"
-  | "month"
-  | "quarter"
-  | "year";
-
-export async function dbGetChatCompletionUsageByApiKeyId({
-  apiKeyId,
-  startDate,
-  endDate,
-}: {
-  apiKeyId: string;
-  startDate: Date;
-  endDate: Date;
-}) {
-  const interval: Interval = "month";
-
-  //@ts-expect-error weird typing errors due to the pg driver
-  const rows: {
-    period: string;
-    model_id: string;
-    prompt_tokens: string;
-    completion_tokens: string;
-    nof_requests: string;
-  }[] = (
-    await db.execute(sql`
-SELECT
-    DATE_TRUNC(${interval}, tracking.created_at) AS period,
-    tracking.model_id,
-    SUM(tracking.prompt_tokens) AS prompt_tokens,
-    SUM(tracking.completion_tokens) AS completion_tokens
-FROM completion_usage_tracking as tracking
-WHERE tracking.created_at BETWEEN ${startDate.toISOString()} AND ${endDate.toISOString()} AND tracking.api_key_id = ${apiKeyId}
-GROUP BY period, tracking.model_id
-ORDER BY period, tracking.model_id
-`)
-  ).rows;
-
-  const mappedRows = rows.map((row) => ({
-    period: new Date(row.period),
-    modelId: row.model_id,
-    promptTokens: getNumberOrDefault(row.prompt_tokens, 0),
-    completionTokens: getNumberOrDefault(row.completion_tokens, 0),
-  }));
-
-  return mappedRows;
-}
-
-/**
- * Retrieves and aggregates image generation usage statistics for a specific API key within a date range.
- *
- * @param apiKeyId - The API key to retrieve usage for
- * @param startDate - The beginning of the date range to analyze (inclusive)
- * @param endDate - The end of the date range to analyze (inclusive)
- *
- * @returns Promise<Array> An array of usage statistics objects, each containing:
- *   - period: Date object representing the month (first day of month)
- *   - modelId: The ID of the model used for image generation
- *   - numberOfImages: Total number of images generated for this model in this period
- */
-export async function dbGetImageGenerationUsageByApiKeyId({
-  apiKeyId,
-  startDate,
-  endDate,
-}: {
-  apiKeyId: string;
-  startDate: Date;
-  endDate: Date;
-}): Promise<
-  Array<{
-    period: Date;
-    modelId: string;
-    numberOfImages: number;
-  }>
-> {
-  const interval: Interval = "month";
-
-  //@ts-expect-error weird typing errors due to the pg driver
-  const rows: {
-    period: string;
-    model_id: string;
-    number_of_images: string;
-    nof_requests: string;
-  }[] = (
-    await db.execute(sql`
-SELECT
-    DATE_TRUNC(${interval}, tracking.created_at) AS period,
-    tracking.model_id,
-    SUM(tracking.number_of_images) AS number_of_images
-FROM image_generation_usage_tracking as tracking
-WHERE tracking.created_at BETWEEN ${startDate.toISOString()} AND ${endDate.toISOString()} AND tracking.api_key_id = ${apiKeyId}
-GROUP BY period, tracking.model_id
-ORDER BY period, tracking.model_id
-`)
-  ).rows;
-
-  const mappedRows = rows.map((row) => ({
-    period: new Date(row.period),
-    modelId: row.model_id,
-    numberOfImages: getNumberOrDefault(row.number_of_images, 0),
-  }));
-
-  return mappedRows;
+  return { apiKey, actualPrice };
 }

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -5,6 +5,7 @@ import {
   text,
   timestamp,
   uuid,
+  real,
 } from "drizzle-orm/pg-core";
 import { Budget, LlmModelPriceMetadata } from "./types";
 import { json } from "drizzle-orm/pg-core";
@@ -102,6 +103,7 @@ export const completionUsageTrackingTable = pgTable(
     completionTokens: integer("completion_tokens").notNull(),
     promptTokens: integer("prompt_tokens").notNull(),
     totalTokens: integer("total_tokens").notNull(),
+    costsInCent: real("costs_in_cent").notNull().default(0),
     modelId: uuid("model_id")
       .references(() => llmModelTable.id)
       .notNull(),
@@ -127,6 +129,7 @@ export const imageGenerationUsageTrackingTable = pgTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
     numberOfImages: integer("number_of_images").notNull(),
+    costsInCent: real("costs_in_cent").notNull().default(0),
     modelId: uuid("model_id")
       .references(() => llmModelTable.id)
       .notNull(),

--- a/packages/database/src/scripts/calculate-existing-costs.ts
+++ b/packages/database/src/scripts/calculate-existing-costs.ts
@@ -19,7 +19,7 @@ import {
 async function updateCompletionUsageCosts() {
   console.log("Starting completion usage cost updates...");
 
-  // Get all completion usage records without costs calculated (costs_in_cent = 0 or null)
+  // Get all completion usage records without costs calculated
   const completionUsages = await db
     .select()
     .from(completionUsageTrackingTable)
@@ -52,7 +52,6 @@ async function updateCompletionUsageCosts() {
   }
 
   let updatedCount = 0;
-
   for (const usage of completionUsages) {
     const model = modelMap.get(usage.modelId);
 
@@ -88,10 +87,6 @@ async function updateCompletionUsageCosts() {
       .where(eq(completionUsageTrackingTable.id, usage.id));
 
     updatedCount++;
-
-    if (updatedCount % 100 === 0) {
-      console.log(`Updated ${updatedCount} completion usage records...`);
-    }
   }
 
   console.log(`Completed updating ${updatedCount} completion usage records`);
@@ -133,7 +128,6 @@ async function updateImageGenerationUsageCosts() {
   }
 
   let updatedCount = 0;
-
   for (const usage of imageUsages) {
     const model = modelMap.get(usage.modelId);
 
@@ -163,10 +157,6 @@ async function updateImageGenerationUsageCosts() {
       .where(eq(imageGenerationUsageTrackingTable.id, usage.id));
 
     updatedCount++;
-
-    if (updatedCount % 100 === 0) {
-      console.log(`Updated ${updatedCount} image generation usage records...`);
-    }
   }
 
   console.log(
@@ -176,8 +166,6 @@ async function updateImageGenerationUsageCosts() {
 
 async function main() {
   try {
-    console.log("Starting cost calculation for existing usage records...");
-
     await updateCompletionUsageCosts();
     await updateImageGenerationUsageCosts();
 

--- a/packages/database/src/scripts/calculate-existing-costs.ts
+++ b/packages/database/src/scripts/calculate-existing-costs.ts
@@ -1,0 +1,193 @@
+/**
+ * Script to calculate and update costs for existing usage records
+ * This script should be run after adding the costs_in_cent column to both tables
+ */
+
+import { db } from "../index";
+import {
+  completionUsageTrackingTable,
+  imageGenerationUsageTrackingTable,
+  llmModelTable,
+} from "../schema";
+import { eq, isNull, or } from "drizzle-orm";
+import {
+  calculatePriceInCentByTextModelAndUsage,
+  calculatePriceInCentByImageModelAndUsage,
+  calculatePriceInCentByEmbeddingModelAndUsage,
+} from "@dgpt/llm-model";
+
+async function updateCompletionUsageCosts() {
+  console.log("Starting completion usage cost updates...");
+
+  // Get all completion usage records without costs calculated (costs_in_cent = 0 or null)
+  const completionUsages = await db
+    .select()
+    .from(completionUsageTrackingTable)
+    .where(
+      or(
+        eq(completionUsageTrackingTable.costsInCent, 0),
+        isNull(completionUsageTrackingTable.costsInCent),
+      ),
+    );
+
+  console.log(
+    `Found ${completionUsages.length} completion usage records to update`,
+  );
+
+  // Get all unique model IDs
+  const modelIds = [...new Set(completionUsages.map((usage) => usage.modelId))];
+
+  // Create a map for quick model lookup
+  const modelMap = new Map();
+  for (const modelId of modelIds) {
+    const modelResult = await db
+      .select()
+      .from(llmModelTable)
+      .where(eq(llmModelTable.id, modelId))
+      .limit(1);
+
+    if (modelResult.length > 0) {
+      modelMap.set(modelId, modelResult[0]);
+    }
+  }
+
+  let updatedCount = 0;
+
+  for (const usage of completionUsages) {
+    const model = modelMap.get(usage.modelId);
+
+    if (!model) {
+      console.warn(`Model not found for usage ${usage.id}: ${usage.modelId}`);
+      continue;
+    }
+
+    let costsInCent = 0;
+
+    if (model.priceMetadata.type === "text") {
+      costsInCent = calculatePriceInCentByTextModelAndUsage({
+        priceMetadata: model.priceMetadata,
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+      });
+    } else if (model.priceMetadata.type === "embedding") {
+      costsInCent = calculatePriceInCentByEmbeddingModelAndUsage({
+        priceMetadata: model.priceMetadata,
+        promptTokens: usage.promptTokens,
+      });
+    } else {
+      console.warn(
+        `Unexpected model type for completion usage ${usage.id}: ${model.priceMetadata.type}`,
+      );
+      continue;
+    }
+
+    // Update the record with calculated costs
+    await db
+      .update(completionUsageTrackingTable)
+      .set({ costsInCent })
+      .where(eq(completionUsageTrackingTable.id, usage.id));
+
+    updatedCount++;
+
+    if (updatedCount % 100 === 0) {
+      console.log(`Updated ${updatedCount} completion usage records...`);
+    }
+  }
+
+  console.log(`Completed updating ${updatedCount} completion usage records`);
+}
+
+async function updateImageGenerationUsageCosts() {
+  console.log("Starting image generation usage cost updates...");
+
+  // Get all image generation usage records without costs calculated
+  const imageUsages = await db
+    .select()
+    .from(imageGenerationUsageTrackingTable)
+    .where(
+      or(
+        eq(imageGenerationUsageTrackingTable.costsInCent, 0),
+        isNull(imageGenerationUsageTrackingTable.costsInCent),
+      ),
+    );
+
+  console.log(
+    `Found ${imageUsages.length} image generation usage records to update`,
+  );
+
+  // Get all unique model IDs
+  const modelIds = [...new Set(imageUsages.map((usage) => usage.modelId))];
+
+  // Create a map for quick model lookup
+  const modelMap = new Map();
+  for (const modelId of modelIds) {
+    const modelResult = await db
+      .select()
+      .from(llmModelTable)
+      .where(eq(llmModelTable.id, modelId))
+      .limit(1);
+
+    if (modelResult.length > 0) {
+      modelMap.set(modelId, modelResult[0]);
+    }
+  }
+
+  let updatedCount = 0;
+
+  for (const usage of imageUsages) {
+    const model = modelMap.get(usage.modelId);
+
+    if (!model) {
+      console.warn(`Model not found for usage ${usage.id}: ${usage.modelId}`);
+      continue;
+    }
+
+    let costsInCent = 0;
+
+    if (model.priceMetadata.type === "image") {
+      costsInCent = calculatePriceInCentByImageModelAndUsage({
+        priceMetadata: model.priceMetadata,
+        numberOfImages: usage.numberOfImages,
+      });
+    } else {
+      console.warn(
+        `Unexpected model type for image usage ${usage.id}: ${model.priceMetadata.type}`,
+      );
+      continue;
+    }
+
+    // Update the record with calculated costs
+    await db
+      .update(imageGenerationUsageTrackingTable)
+      .set({ costsInCent })
+      .where(eq(imageGenerationUsageTrackingTable.id, usage.id));
+
+    updatedCount++;
+
+    if (updatedCount % 100 === 0) {
+      console.log(`Updated ${updatedCount} image generation usage records...`);
+    }
+  }
+
+  console.log(
+    `Completed updating ${updatedCount} image generation usage records`,
+  );
+}
+
+async function main() {
+  try {
+    console.log("Starting cost calculation for existing usage records...");
+
+    await updateCompletionUsageCosts();
+    await updateImageGenerationUsageCosts();
+
+    console.log("Cost calculation completed successfully!");
+  } catch (error) {
+    console.error("Error during cost calculation:", error);
+    process.exit(1);
+  } finally {
+    process.exit(0);
+  }
+}
+
+main();

--- a/packages/llm-model/src/utils.ts
+++ b/packages/llm-model/src/utils.ts
@@ -25,3 +25,14 @@ export function calculatePriceInCentByImageModelAndUsage({
 }) {
   return numberOfImages * priceMetadata.pricePerImageInCent;
 }
+
+export function calculatePriceInCentByEmbeddingModelAndUsage({
+  promptTokens,
+  priceMetadata,
+}: {
+  priceMetadata: { promptTokenPrice: number };
+  promptTokens: number;
+}) {
+  const promptTokenPrice = promptTokens * priceMetadata.promptTokenPrice;
+  return promptTokenPrice / PRICE_AND_CENT_MULTIPLIER;
+}


### PR DESCRIPTION
This is a major refactoring regarding the costs computation and storage.

- Added `costs_in_cent` column to `completion_usage_tracking` and `image_generation_usage_tracking` table. Now the costs are preserved, even when a model is deleted or a price has changed.
- Optimized cost calculation via database-level aggregation - Let the database do the summing instead of the application code
- Used clean TypeScript with proper Drizzle ORM and removed complex raw SQL queries from the code
- Embedding costs are now also handled
- Removed x-llm-provider from the header, since we do not use this
- Removed many lines of code :D

The cost calculation script (`calculate-existing-costs.ts`) should be run once after the migration to populate costs for existing usage records.

1. **Run the database migration:**

   ```bash
   cd packages/database
   pnpm db:migrate
   ```

2. **Calculate costs for existing records:**
   ```bash
   cd packages/database
   pnpm db:calculate-costs
   ```

Part 2 will include some tests and add price units to the text model schema.