### PR TITLE
provide codecov token in action

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Run integration tests
         run: pnpm run test
 
-      - name: Upload coverage results
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage results to Codecov
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./apps/api/coverage/lcov.info


### PR DESCRIPTION
In order to get codecov working we have to provide a codecov token that was created in the github secrets for actions.